### PR TITLE
chore: add golangci-lint for backend

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,70 @@
+name: Backend CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - "gen/go/**"
+      - ".github/workflows/backend-ci.yml"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4.0.1
+        with:
+          install: true
+          cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('backend/go.sum', 'gen/go/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v9.2.0
+        with:
+          working-directory: backend
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4.0.1
+        with:
+          install: true
+          cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('backend/go.sum', 'gen/go/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download dependencies
+        run: go work sync
+
+      - name: Build
+        run: go build ./backend/...

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,6 +1,3 @@
 version: "2"
 linters:
   default: standard
-issues:
-  exclude-dirs:
-    - ../gen

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,0 +1,6 @@
+version: "2"
+linters:
+  default: standard
+issues:
+  exclude-dirs:
+    - ../gen

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -4,8 +4,9 @@ WORKDIR /app
 
 # Install development tools
 RUN go install github.com/air-verse/air@latest
-RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.28.0
 RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
 # Pre-fetch modules
 COPY go.work go.work.sum ./

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -58,7 +58,13 @@ migrate-create:
 # Tools
 # -------------------------------------------------------------------
 
-.PHONY: sqlc
+.PHONY: lint fmt sqlc
+
+lint:
+	$(DOCKER_EXEC) sh -c 'cd backend && golangci-lint run ./...'
+
+fmt:
+	$(DOCKER_EXEC) sh -c 'cd backend && golangci-lint fmt ./...'
 
 sqlc:
 	$(DOCKER_EXEC) sqlc generate -f backend/sqlc.yaml

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -54,10 +54,10 @@ func Load() (*Config, error) {
 		GoogleClientID:       googleClientID,
 		GoogleClientSecret:   googleClientSecret,
 		GoogleNativeClientID: googleNativeClientID,
-		GoogleCallbackURL:  getEnvOrDefault("GOOGLE_CALLBACK_URL", "http://localhost:8080/auth/callback"),
-		WebFrontendURL:     getEnvOrDefault("WEB_FRONTEND_URL", "http://localhost:3000"),
-		JWTSecret:          jwtSecret,
-		CookieSecure:       os.Getenv("COOKIE_SECURE") == "true",
+		GoogleCallbackURL:    getEnvOrDefault("GOOGLE_CALLBACK_URL", "http://localhost:8080/auth/callback"),
+		WebFrontendURL:       getEnvOrDefault("WEB_FRONTEND_URL", "http://localhost:3000"),
+		JWTSecret:            jwtSecret,
+		CookieSecure:         os.Getenv("COOKIE_SECURE") == "true",
 	}, nil
 }
 

--- a/backend/internal/handler/auth_callback.go
+++ b/backend/internal/handler/auth_callback.go
@@ -137,7 +137,7 @@ func fetchGoogleUserInfo(ctx context.Context, cfg *oauth2.Config, token *oauth2.
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("google userinfo: unexpected status %d", resp.StatusCode)

--- a/backend/internal/initializer/server.go
+++ b/backend/internal/initializer/server.go
@@ -31,11 +31,11 @@ func BuildServer(_ context.Context) (*http.Server, *config.Config, func(), error
 		return nil, nil, func() {}, err
 	}
 	if err := conn.Ping(); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, nil, func() {}, err
 	}
 	cleanup := func() {
-		conn.Close()
+		_ = conn.Close()
 	}
 
 	queries := db.New(conn)


### PR DESCRIPTION
## Summary

- `golangci-lint` をローカル（Docker コンテナ経由）と CI（GitHub Actions）の両方に導入
- `backend/.golangci.yml` を追加（`standard` linter セット、`gen/` 配下を除外）
- `backend/Makefile` に `make lint` / `make fmt` ターゲットを追加
- `.github/workflows/backend-ci.yml` を追加（`Lint` + `Build` の2ジョブ）
- `sqlc@latest` を `v1.28.0` に固定（v1.31.0 の replace ディレクティブで `go install` が失敗する問題を回避）
- lint で検出された `errcheck` 違反を修正（`resp.Body.Close`、`conn.Close` の戻り値）

## Test plan

- [ ] `make docker-build` でイメージが正常にビルドされること
- [ ] `make lint` でエラーが出ないこと
- [ ] `make fmt` が正常に実行されること
- [ ] PR の CI（Backend CI ワークフロー）が green になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)