### PR TITLE
test(backend): add unit tests for jwt and config

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -68,3 +68,33 @@ jobs:
 
       - name: Build
         run: go build ./backend/...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4.0.1
+        with:
+          install: true
+          cache: true
+
+      - name: Cache Go modules
+        uses: actions/cache@v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('backend/go.sum', 'gen/go/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download dependencies
+        run: go work sync
+
+      - name: Test
+        run: go test -count=1 ./backend/...

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -2,6 +2,10 @@ BACKEND_CONTAINER_NAME ?= connect-rpc-todo-backend
 
 MIGRATION_DIR ?= backend/db/migrations
 NAME          ?=
+PKG           ?=
+FILE          ?=
+RUN           ?=
+TEST_FLAGS    ?= -count=1
 
 ifneq (,$(wildcard ../.env))
 include ../.env
@@ -14,10 +18,35 @@ DOCKER_EXEC := docker exec -i $(BACKEND_CONTAINER_NAME)
 # App
 # -------------------------------------------------------------------
 
-.PHONY: build
+.PHONY: build test test-pkg test-file test-run
 
 build:
 	$(DOCKER_EXEC) go build ./backend/...
+
+# -------------------------------------------------------------------
+# Test
+# -------------------------------------------------------------------
+
+# 全テストを実行
+test:
+	$(DOCKER_EXEC) sh -c 'cd backend && go test $(TEST_FLAGS) ./...'
+
+# パッケージ単位でテスト実行。例: make test-pkg PKG=./internal/auth
+test-pkg:
+	@test -n "$(PKG)" || (echo "PKG is required, e.g. make test-pkg PKG=./internal/auth"; exit 1)
+	$(DOCKER_EXEC) sh -c 'cd backend && go test $(TEST_FLAGS) $(PKG)'
+
+# 特定ファイルのテストを実行。例: make test-file FILE=internal/auth/jwt_test.go
+test-file:
+	@test -n "$(FILE)" || (echo "FILE is required, e.g. make test-file FILE=internal/auth/jwt_test.go"; exit 1)
+	@dir=$$(dirname $(FILE)); \
+	$(DOCKER_EXEC) sh -c 'cd backend && go test $(TEST_FLAGS) ./$$dir'
+
+# 特定テスト名（regexp）を実行。例: make test-run PKG=./internal/auth RUN=TestSignAndValidateJWT
+test-run:
+	@test -n "$(PKG)" || (echo "PKG is required, e.g. make test-run PKG=./internal/auth RUN=TestSignAndValidateJWT"; exit 1)
+	@test -n "$(RUN)" || (echo "RUN is required, e.g. make test-run PKG=./internal/auth RUN=TestSignAndValidateJWT"; exit 1)
+	$(DOCKER_EXEC) sh -c 'cd backend && go test $(TEST_FLAGS) -run $(RUN) $(PKG)'
 
 # -------------------------------------------------------------------
 # Docker

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -1,0 +1,123 @@
+package auth_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"todo-app/backend/internal/auth"
+	"todo-app/backend/internal/config"
+)
+
+func testConfig(secret string) *config.Config {
+	return &config.Config{JWTSecret: secret}
+}
+
+func TestSignAndValidateJWT(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig("test-secret")
+	userID := "user-123"
+
+	token, err := auth.SignJWT(cfg, userID)
+	if err != nil {
+		t.Fatalf("SignJWT failed: %v", err)
+	}
+	if token == "" {
+		t.Fatal("SignJWT returned empty token")
+	}
+
+	got, err := auth.ValidateJWT(cfg, token)
+	if err != nil {
+		t.Fatalf("ValidateJWT failed: %v", err)
+	}
+	if got != userID {
+		t.Errorf("ValidateJWT userID = %q, want %q", got, userID)
+	}
+}
+
+func TestValidateJWT_ExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig("test-secret")
+
+	claims := auth.Claims{
+		UserID: "user-expired",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-1 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenStr, err := token.SignedString([]byte(cfg.JWTSecret))
+	if err != nil {
+		t.Fatalf("failed to sign expired token: %v", err)
+	}
+
+	_, err = auth.ValidateJWT(cfg, tokenStr)
+	if err == nil {
+		t.Fatal("ValidateJWT should fail for expired token, but got nil error")
+	}
+}
+
+func TestValidateJWT_TamperedToken(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig("test-secret")
+
+	token, err := auth.SignJWT(cfg, "user-123")
+	if err != nil {
+		t.Fatalf("SignJWT failed: %v", err)
+	}
+
+	// 末尾1文字を変えて改ざん
+	tampered := token[:len(token)-1] + "X"
+
+	_, err = auth.ValidateJWT(cfg, tampered)
+	if err == nil {
+		t.Fatal("ValidateJWT should fail for tampered token, but got nil error")
+	}
+}
+
+func TestValidateJWT_WrongSigningMethod(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig("test-secret")
+
+	// テスト専用 RSA 鍵を生成して RS256 で署名
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	claims := auth.Claims{
+		UserID: "user-rsa",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenStr, err := token.SignedString(rsaKey)
+	if err != nil {
+		t.Fatalf("failed to sign with RSA: %v", err)
+	}
+
+	_, err = auth.ValidateJWT(cfg, tokenStr)
+	if err == nil {
+		t.Fatal("ValidateJWT should fail for RS256-signed token, but got nil error")
+	}
+}
+
+func TestValidateJWT_EmptyToken(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig("test-secret")
+
+	_, err := auth.ValidateJWT(cfg, "")
+	if err == nil {
+		t.Fatal("ValidateJWT should fail for empty token, but got nil error")
+	}
+}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -19,14 +19,20 @@ func clearEnv(t *testing.T) {
 	saved := make(map[string]string, len(keys))
 	for _, k := range keys {
 		saved[k] = os.Getenv(k)
-		os.Unsetenv(k)
+		if err := os.Unsetenv(k); err != nil {
+			t.Fatalf("os.Unsetenv(%q): %v", k, err)
+		}
 	}
 	t.Cleanup(func() {
 		for k, v := range saved {
 			if v != "" {
-				os.Setenv(k, v)
+				if err := os.Setenv(k, v); err != nil {
+					t.Errorf("os.Setenv(%q): %v", k, err)
+				}
 			} else {
-				os.Unsetenv(k)
+				if err := os.Unsetenv(k); err != nil {
+					t.Errorf("os.Unsetenv(%q): %v", k, err)
+				}
 			}
 		}
 	})

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,163 @@
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	"todo-app/backend/internal/config"
+)
+
+// clearEnv は config.Load() が参照する全 env vars をクリアして
+// テスト終了後に元の値を復元する。
+func clearEnv(t *testing.T) {
+	t.Helper()
+	keys := []string{
+		"DATABASE_URL", "SERVER_PORT", "JWT_SECRET",
+		"GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET", "GOOGLE_NATIVE_CLIENT_ID",
+		"GOOGLE_CALLBACK_URL", "WEB_FRONTEND_URL", "COOKIE_SECURE",
+	}
+	saved := make(map[string]string, len(keys))
+	for _, k := range keys {
+		saved[k] = os.Getenv(k)
+		os.Unsetenv(k)
+	}
+	t.Cleanup(func() {
+		for k, v := range saved {
+			if v != "" {
+				os.Setenv(k, v)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	})
+}
+
+// setRequired は Load() に必要な最低限の env vars を設定する。
+func setRequired(t *testing.T) {
+	t.Helper()
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/testdb")
+	t.Setenv("JWT_SECRET", "test-jwt-secret")
+	t.Setenv("GOOGLE_CLIENT_ID", "test-google-client-id")
+}
+
+func TestLoad_Success(t *testing.T) {
+	clearEnv(t)
+	setRequired(t)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.DatabaseURL != "postgres://user:pass@localhost/testdb" {
+		t.Errorf("DatabaseURL = %q, want %q", cfg.DatabaseURL, "postgres://user:pass@localhost/testdb")
+	}
+	if cfg.JWTSecret != "test-jwt-secret" {
+		t.Errorf("JWTSecret = %q, want %q", cfg.JWTSecret, "test-jwt-secret")
+	}
+	if cfg.GoogleClientID != "test-google-client-id" {
+		t.Errorf("GoogleClientID = %q, want %q", cfg.GoogleClientID, "test-google-client-id")
+	}
+}
+
+func TestLoad_DefaultServerPort(t *testing.T) {
+	clearEnv(t)
+	setRequired(t)
+	// SERVER_PORT は未設定のまま
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.ServerPort != 8080 {
+		t.Errorf("ServerPort = %d, want 8080 (default)", cfg.ServerPort)
+	}
+}
+
+func TestLoad_CustomServerPort(t *testing.T) {
+	clearEnv(t)
+	setRequired(t)
+	t.Setenv("SERVER_PORT", "9090")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.ServerPort != 9090 {
+		t.Errorf("ServerPort = %d, want 9090", cfg.ServerPort)
+	}
+}
+
+func TestLoad_InvalidServerPort(t *testing.T) {
+	clearEnv(t)
+	setRequired(t)
+	t.Setenv("SERVER_PORT", "not-a-number")
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("Load should fail for invalid SERVER_PORT, but got nil error")
+	}
+}
+
+func TestLoad_CookieSecureTrue(t *testing.T) {
+	clearEnv(t)
+	setRequired(t)
+	t.Setenv("COOKIE_SECURE", "true")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if !cfg.CookieSecure {
+		t.Error("CookieSecure should be true when COOKIE_SECURE=true")
+	}
+}
+
+func TestLoad_CookieSecureFalse(t *testing.T) {
+	clearEnv(t)
+	setRequired(t)
+	// COOKIE_SECURE は未設定のまま
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.CookieSecure {
+		t.Error("CookieSecure should be false when COOKIE_SECURE is not set")
+	}
+}
+
+func TestLoad_MissingDatabaseURL(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("JWT_SECRET", "test-jwt-secret")
+	t.Setenv("GOOGLE_CLIENT_ID", "test-google-client-id")
+	// DATABASE_URL は未設定のまま
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("Load should fail when DATABASE_URL is not set, but got nil error")
+	}
+}
+
+func TestLoad_MissingJWTSecret(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/testdb")
+	t.Setenv("GOOGLE_CLIENT_ID", "test-google-client-id")
+	// JWT_SECRET は未設定のまま
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("Load should fail when JWT_SECRET is not set, but got nil error")
+	}
+}
+
+func TestLoad_MissingGoogleClientID(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/testdb")
+	t.Setenv("JWT_SECRET", "test-jwt-secret")
+	// GOOGLE_CLIENT_ID は未設定のまま
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("Load should fail when GOOGLE_CLIENT_ID is not set, but got nil error")
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/auth/jwt_test.go` を新規追加：`SignJWT` / `ValidateJWT` のユニットテスト（正常系・期限切れ・改ざん・署名方式違い・空文字）
- `internal/config/config_test.go` を新規追加：`config.Load()` のユニットテスト（必須 env vars・デフォルト値・不正値）
- `backend/Makefile` に `test` / `test-pkg` / `test-file` / `test-run` ターゲットを追加
- `.github/workflows/backend-ci.yml` に `test` ジョブを追加

## Test plan

- [ ] `make test` で全テストがパスすることを確認
- [ ] `make test-pkg PKG=./internal/auth` で jwt テストのみ実行できることを確認
- [ ] `make test-pkg PKG=./internal/config` で config テストのみ実行できることを確認
- [ ] CI の `test` ジョブが PR でグリーンになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)