### PR TITLE
ci: add web and native CI workflows

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -1,0 +1,52 @@
+name: Native CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "native/**"
+      - "gen/ts/**"
+      - ".github/workflows/native-ci.yml"
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: native
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4.0.1
+        with:
+          install: true
+          cache: true
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type Check
+        run: pnpm type:check
+
+      - name: Build (prebuild)
+        run: pnpm run prebuild -- --no-install

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,52 @@
+name: Web CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "web/**"
+      - "gen/ts/**"
+      - ".github/workflows/web-ci.yml"
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4.0.1
+        with:
+          install: true
+          cache: true
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type Check
+        run: pnpm type:check
+
+      - name: Build
+        run: pnpm build

--- a/web/app/routes/__root.tsx
+++ b/web/app/routes/__root.tsx
@@ -3,6 +3,7 @@ import { TransportProvider } from '@connectrpc/connect-query'
 import { createGrpcWebTransport } from '@connectrpc/connect-web'
 import { type QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
+import { createIsomorphicFn } from '@tanstack/react-start'
 import { AuthService } from '@todo-app/api-client/src/auth/v1/auth_pb.js'
 import type { ReactNode } from 'react'
 import { env } from '~/lib/env'
@@ -24,6 +25,22 @@ export interface AuthContext {
 
 const API_BASE = env.VITE_API_URL
 
+// SSR 時はリクエストの Cookie をバックエンドへ転送するトランスポートを使用する
+const getAuthTransport = createIsomorphicFn()
+  .client(() => transport)
+  .server(async () => {
+    const { getRequestHeader } = await import('@tanstack/react-start/server')
+    const cookieHeader = getRequestHeader('cookie') ?? ''
+    return createGrpcWebTransport({
+      baseUrl: API_BASE,
+      fetch: (input, init) => {
+        const headers = new Headers(init?.headers)
+        if (cookieHeader) headers.set('cookie', cookieHeader)
+        return fetch(input as string, { ...(init as RequestInit), headers })
+      },
+    })
+  })
+
 function NotFound() {
   return <p>Not Found</p>
 }
@@ -31,22 +48,7 @@ function NotFound() {
 export const Route = createRootRouteWithContext<RouterContext>()({
   notFoundComponent: NotFound,
   beforeLoad: async (): Promise<{ auth: AuthContext }> => {
-    let authTransport = transport
-
-    if (typeof window === 'undefined') {
-      // SSR: 受信リクエストの Cookie をバックエンドへ転送する
-      const { getRequestHeader } = await import('@tanstack/react-start/server')
-      const cookieHeader = getRequestHeader('cookie') ?? ''
-      authTransport = createGrpcWebTransport({
-        baseUrl: API_BASE,
-        fetch: (input, init) => {
-          const headers = new Headers(init?.headers)
-          if (cookieHeader) headers.set('cookie', cookieHeader)
-          return fetch(input as string, { ...(init as RequestInit), headers })
-        },
-      })
-    }
-
+    const authTransport = await getAuthTransport()
     const client = createClient(AuthService, authTransport)
     try {
       const me = await client.getMe({})


### PR DESCRIPTION
## Summary

- `web-ci.yml`: PR 時に lint → type-check → build を直列実行（Biome + tsc + Vite build）
- `native-ci.yml`: PR 時に lint → type-check → build を直列実行（Biome + tsc + expo prebuild）
- パスフィルタで `web/**`, `native/**`, `gen/ts/**` の変更時のみ起動

## Test plan

- [ ] PR を作成して各ワークフローが起動することを確認
- [ ] `web/**` 変更時に web-ci のみ、`native/**` 変更時に native-ci のみが起動することを確認
- [ ] lint エラーがあるコードで CI が失敗することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)